### PR TITLE
Fix: Build error on newer hyprutils versions

### DIFF
--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -169,5 +169,5 @@ void CSeatManager::registerCursorShape(SP<CCWpCursorShapeManagerV1> shape) {
 }
 
 bool CSeatManager::registered() {
-    return m_pSeat;
+    return !!m_pSeat;
 }


### PR DESCRIPTION
This fixes the following error:

```c++
/home/kaii/hyprlogin/src/hyprlogin-src/src/core/Seat.cpp:172:12: error: cannot convert ‘Hyprutils::Memory::CSharedPointer<CCWlSeat>’ to ‘bool’ in return
  172 |     return m_pSeat;
      |            ^~~~~~~
      |            |
      |            Hyprutils::Memory::CSharedPointer<CCWlSeat>
```

Probably should update the rest of the codebase from upstream though, this is just to keep using the current hyprlogin version with new hyprutils versions.