### PR TITLE
Migrate Hyprland greeter config from hyprlang to Lua format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .direnv
 .envrc
 .vscode/
+.idea/
 .makepkg-build/
 .makepkg-staged-src/
 pkg/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ install(
   RENAME hyprlogin.conf)
 
 install(
-  FILES ${CMAKE_SOURCE_DIR}/assets/hyprland-greeter.conf
+  FILES ${CMAKE_SOURCE_DIR}/assets/hyprland-greeter.lua
   DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/hyprlogin)
 
 install(

--- a/README.md
+++ b/README.md
@@ -42,20 +42,22 @@ Typical `greetd` setup:
 
 ```toml
 [default_session]
-command = "start-hyprland --config /etc/hyprlogin/hyprland.conf"
+command = "start-hyprland --config /etc/hyprlogin/hyprland.lua"
 user = "greeter"
 ```
 
 Example Hyprland config:
 
-```ini
-exec-once = hyprlogin
+```lua
+hl.on("hyprland.start", function()
+    hl.exec_cmd("hyprlogin --verbose")
+end)
 ```
 
 Installed sample files:
 
 - `/usr/share/hyprlogin/examples/hyprlogin.conf`
-- `/usr/share/hyprlogin/hyprland-greeter.conf`
+- `/usr/share/hyprlogin/hyprland-greeter.lua`
 - `/usr/share/hyprlogin/greetd-config.toml`
 
 ## Install and Use
@@ -71,7 +73,7 @@ Main paths after install:
 - `/usr/bin/hyprlogin`
 - `/etc/hyprlogin/hyprlogin.conf`
 - `/usr/share/hyprlogin/examples/hyprlogin.conf`
-- `/usr/share/hyprlogin/hyprland-greeter.conf`
+- `/usr/share/hyprlogin/hyprland-greeter.lua`
 - `/usr/share/hyprlogin/greetd-config.toml`
 
 Minimal setup:
@@ -84,7 +86,7 @@ Minimal setup:
 vt = 1
 
 [default_session]
-command = "start-hyprland -- --config /usr/share/hyprlogin/hyprland-greeter.conf"
+command = "start-hyprland -- --config /usr/share/hyprlogin/hyprland-greeter.lua"
 user = "greeter"
 ```
 

--- a/assets/greetd-config.toml
+++ b/assets/greetd-config.toml
@@ -2,5 +2,5 @@
 vt = 1
 
 [default_session]
-command = "start-hyprland -- --config /usr/share/hyprlogin/hyprland-greeter.conf"
+command = "start-hyprland -- --config /usr/share/hyprlogin/hyprland-greeter.lua"
 user = "greeter"

--- a/assets/hyprland-greeter.conf
+++ b/assets/hyprland-greeter.conf
@@ -1,8 +1,0 @@
-exec-once = hyprlogin --verbose
-monitor=,preferred,auto,1
-
-input {
-    kb_layout = us,fr
-    kb_variant = ,azerty
-    kb_options = grp:alt_shift_toggle
-}

--- a/assets/hyprland-greeter.lua
+++ b/assets/hyprland-greeter.lua
@@ -1,0 +1,21 @@
+-- Hyprland config for the hyprlogin greeter session.
+-- https://wiki.hypr.land/Configuring/Start/
+
+hl.on("hyprland.start", function()
+    hl.exec_cmd("hyprlogin --verbose")
+end)
+
+hl.monitor({
+    output   = "",
+    mode     = "preferred",
+    position = "auto",
+    scale    = 1,
+})
+
+hl.config({
+    input = {
+        kb_layout  = "us,fr",
+        kb_variant = ",azerty",
+        kb_options = "grp:alt_shift_toggle",
+    },
+})


### PR DESCRIPTION
As found [here](https://wiki.hypr.land/Configuring/Start/), since hyprland 0.55, the hyprlang was deprecated in favor of lua.

This PR updates the hyprland example config file to its format.